### PR TITLE
Javascript requirements fix for 3.0 backend

### DIFF
--- a/code/AutoCompleteField.php
+++ b/code/AutoCompleteField.php
@@ -90,7 +90,6 @@ class AutoCompleteField extends TextField {
 		// jQuery Autocomplete Requirements
 		Requirements::css(THIRDPARTY_DIR . '/jquery-ui-themes/smoothness/jquery-ui.css');
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
-		Requirements::javascript(THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery-ui/jquery-ui.js');
 
 		// init script for this field


### PR DESCRIPTION
I was finding that when this module was present, javascript from other modules was not being loaded correctly. I was getting error messages about entwine not being present. The problem was that using the minified versions of jquery and jquery-ui was overwriting the version version the cms includes by default. Tested against 3.0.2 and current master. Thanks.
