### PR TITLE
Updated composer.json to require stable 3.1 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
 	"require":
 	{
-		"silverstripe/framework": ">=3.1.x-dev,<4.0"
+		"silverstripe/framework": "~3.1"
 	},
     "extra": {
         "installer-name": "autocomplete"


### PR DESCRIPTION
First PR, so sorry if this is submitted incorrectly. Attempted to install the auto-complete module and seemed to have issues with requirement of a dev version in the composer.json
