### PR TITLE
Move input selection above free text to allow stored value to used

### DIFF
--- a/javascript/AutocompleteField.js
+++ b/javascript/AutocompleteField.js
@@ -23,17 +23,17 @@
 				change: function( event, ui ) {
 					var hiddenInput = input.parent().find(':hidden');
 
+					// Accept if item selected from list
+					if(ui.item) {
+						hiddenInput.val(ui.item.stored);
+						return true;
+					}
+
 					// Check if a selection from the list is required
 					if(!input.attr('data-require-selection')) {
 						// free text is allowed, use it
 						hiddenInput.val(input[0].value);
 
-						return true;
-					}
-
-					// Accept if item selected from list
-					if(ui.item) {
-						hiddenInput.val(ui.item.stored);
 						return true;
 					}
 


### PR DESCRIPTION
Currently the hiddenInput won't be set to the stored value when an item in the list is clicked.
Instead the value is set to the value of the displayField, moving the block above the free-text check sets the stored value correctly while still allowing free text.