### PR TITLE
Fix multi word search, UX improvements

### DIFF
--- a/code/AutoCompleteField.php
+++ b/code/AutoCompleteField.php
@@ -119,15 +119,19 @@ class AutoCompleteField extends TextField
      */
     public function getAttributes()
     {
-        return array_merge(
+        $atts = array_merge(
             parent::getAttributes(), array(
                 'data-source' => $this->getSuggestURL(),
                 'data-min-length' => $this->getMinSearchLength(),
                 'data-require-selection' => $this->getRequireSelection(),
                 'autocomplete' => 'off',
-                'name' => $this->getName() . '__autocomplete'
+                'name' => $this->getName() . '__autocomplete',
+                'placeholder' => 'Search on ' . implode(' or ', $this->getSourceFields())
             )
         );
+        // Unset the value so we start with a clear search form
+        $atts['value'] = null;
+        return $atts;
     }
 
     /**
@@ -150,8 +154,14 @@ class AutoCompleteField extends TextField
         Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
         Requirements::javascript(THIRDPARTY_DIR . '/jquery-ui/jquery-ui.js');
 
+        // Entwine requirements
+        Requirements::javascript(THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
+
         // init script for this field
         Requirements::javascript(AUTOCOMPLETEFIELD_DIR . '/javascript/AutocompleteField.js');
+
+        // styles for this field
+        Requirements::css(AUTOCOMPLETEFIELD_DIR . '/css/AutocompleteField.css');
 
         return parent::Field($properties);
     }

--- a/code/AutoCompleteField.php
+++ b/code/AutoCompleteField.php
@@ -481,7 +481,7 @@ class AutoCompleteField extends TextField
             return;
         }
 
-        // Find field to search within
+        // Find fields to search within
         $sourceFields = $this->getSourceFields();
 
         // input
@@ -489,11 +489,8 @@ class AutoCompleteField extends TextField
         $limit = $this->getLimit();
 
         $filters = array();
-
-        foreach (preg_split('/[\s,]+/', $q) as $keyword) {
-            foreach ($sourceFields as $sourceField) {
-                $filters["{$sourceField}:PartialMatch"] = $keyword;
-            }
+        foreach ($sourceFields as $sourceField) {
+            $filters["{$sourceField}:PartialMatch"] = $q;
         }
 
         // Generate query

--- a/css/AutocompleteField.css
+++ b/css/AutocompleteField.css
@@ -1,0 +1,23 @@
+input.text.autocomplete ~ .value-holder {
+    display: block;
+    margin: 4px 0 0 0;
+    color: #626e79;
+}
+input.text.autocomplete ~ .value-holder .value {
+    padding: .25em;
+    display: inline-block;
+    border-bottom: 1px solid transparent;
+}
+input.text.autocomplete ~ .value-holder.has-value .value {
+    color: #4f5861;
+}
+input.text.autocomplete ~ .value-holder .clear {
+    display: none;
+    padding: .25em .5em;
+    border-radius: .25em;
+    background: #fff;
+    border-bottom: 1px solid #e8e8e8;
+}
+input.text.autocomplete ~ .value-holder.has-value .clear {
+    display: inline-block;
+}

--- a/templates/AutoCompleteField.ss
+++ b/templates/AutoCompleteField.ss
@@ -1,2 +1,3 @@
 <input $AttributesHTML>
 <input type="hidden" name="$Name" value="$dataValue">
+<span class="value-holder<% if $Value %> has-value<% end_if %>">Selected: <em class="value" data-empty-val="(none)"><% if $Value %>$Value<% else %>(none)<% end_if %></em> <a href="#" class="clear">Clear ×</a></span>


### PR DESCRIPTION
Some fairly significant changes here. Hope you like 'em :)

![screen shot 2016-04-28 at 12 54 01 pm](https://cloud.githubusercontent.com/assets/1079425/14900236/6d57ed1e-0d44-11e6-9723-68f0af1f8259.png)

**Fix:**
* Bugfix for multi-word search terms

**New:**
* Display field value below search field so it is clear what is being stored
* Show searchable fields with placeholder text
* Add autocomplete functionality to field immediately instead of on focus
* Allow clearing of selection
* Open autocomplete dropdown menu on click/focus if the field contains a value

**To do** (maybe):
Is there a helper somewhere in the CMS for translating field dot notation in to a friendly name? E.g. "Client.Title" --> "Client Title", "StandNumber" --> "Stand Number"