### PR TITLE
Issue #34: Ability to enable/disable population of entered value into area separate from the input field. Also option for clearing input field when separate area is populated. 

### DIFF
--- a/code/AutoCompleteField.php
+++ b/code/AutoCompleteField.php
@@ -96,6 +96,22 @@ class AutoCompleteField extends TextField
     protected $storedField = 'ID';
 
     /**
+     * Indicate if results (when selected) should be populated underneath the text field instead of inside of the text field.
+     *
+     * @var bool
+     */
+    protected $populateSeparately = false;
+
+    /**
+     * Clears the search input field field when a selection has been made.
+     *
+     * NOTE: Only applies to when populating separately.
+     *
+     * @var bool
+     */
+    protected $clearInput = true;
+
+    /**
      * @param string      $name         The name of the field.
      * @param null|string $title        The title to use in the form.
      * @param string      $value        The initial value of this field.
@@ -124,13 +140,17 @@ class AutoCompleteField extends TextField
                 'data-source' => $this->getSuggestURL(),
                 'data-min-length' => $this->getMinSearchLength(),
                 'data-require-selection' => $this->getRequireSelection(),
+                'data-pop-separate' => $this->getPopulateSeparately(),
+                'data-clear-input' => $this->getClearInput(),
                 'autocomplete' => 'off',
                 'name' => $this->getName() . '__autocomplete',
                 'placeholder' => 'Search on ' . implode(' or ', $this->getSourceFields())
             )
         );
-        // Unset the value so we start with a clear search form
-        $atts['value'] = null;
+
+        // Override the value so we start with a clear search form (depending on configuration).
+        $atts['value'] = ($this->getPopulateSeparately() ? null : $this->Value());
+
         return $atts;
     }
 
@@ -449,6 +469,42 @@ class AutoCompleteField extends TextField
 
         // Attempt to link back to itself
         return parse_url($this->Link(), PHP_URL_PATH) . '/Suggest';
+    }
+
+    /**
+     * @param bool $populateSeparately
+     * @return static
+     */
+    public function setPopulateSeparately($populateSeparately)
+    {
+        $this->populateSeparately = $populateSeparately;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getPopulateSeparately()
+    {
+        return $this->populateSeparately;
+    }
+
+    /**
+     * @param bool $clearInput
+     * @return static
+     */
+    public function setClearInput($clearInput)
+    {
+        $this->clearInput = $clearInput;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getClearInput()
+    {
+        return $this->clearInput;
     }
 
     /**

--- a/templates/AutoCompleteField.ss
+++ b/templates/AutoCompleteField.ss
@@ -1,3 +1,15 @@
 <input $AttributesHTML>
 <input type="hidden" name="$Name" value="$dataValue">
-<span class="value-holder<% if $Value %> has-value<% end_if %>">Selected: <em class="value" data-empty-val="(none)"><% if $Value %>$Value<% else %>(none)<% end_if %></em> <a href="#" class="clear">Clear ×</a></span>
+<% if $PopulateSeparately %>
+    <span class="value-holder<% if $Value %> has-value<% end_if %>">
+        Selected:
+        <em class="value" data-empty-val="(none)">
+            <% if $Value %>
+                $Value
+            <% else %>
+                (none)
+            <% end_if %>
+        </em>
+        <a href="#" class="clear">Clear ×</a>
+    </span>
+<% end_if %>


### PR DESCRIPTION
To address #34. List of modifications:

- Ability to enable/disable population of entered value into area separate from the input field. 
- Option for clearing input field when separate area is populated.
- Using `$` to prefix and differentiate jQuery selectors from other variables.
- Consolidated (and made consistent) use/references to `.data(...)` configuration values for everything except `data-loaded` since that may be referenced externally (trying to be self-contained).
- Relocated `focus` functionality into main `onmatch` scope to help with this consolidation and due to `entwine`; much easier to just share scope once it's initialized instead of building out a ton of methods here.
- Broke HTML up into multiple lines to help make easier to read and diff for future modifications.

Also note:

- Defaults to `$populateSeparately` to `false` as this is new functionality circa `3.4.0`.
- Defaults `$clearInput` to `true` since this is cleaner in my highly subjective opinion.