### PR TITLE
fix for issue #36 - find all keywords across any of the source fields

### DIFF
--- a/code/AutoCompleteField.php
+++ b/code/AutoCompleteField.php
@@ -559,14 +559,14 @@ class AutoCompleteField extends TextField
             ->sort($this->sourceSort)
             ->limit($limit);
 
-        // Go through each source field and apply each keyword separately using ->filter() to ensure they are combined via "AND".
+        // Fetch results that match all of the keywords across any of the source fields
         $keywords = preg_split('/[\s,]+/', $q);
-        foreach ($sourceFields as $sourceField) {
-            foreach($keywords as $keyword) {
-                $query = $query->filter([
-                    "{$sourceField}:PartialMatch" => $keyword
-                ]);
+        foreach($keywords as $keyword) {
+            $filters = array();
+            foreach ($sourceFields as $sourceField) {
+                $filters["{$sourceField}:PartialMatch"] = $keyword;
             }
+            $query = $query->filterAny($filters);
         }
 
         if ($this->sourceFilter) {


### PR DESCRIPTION
Rather than having to find all keywords in all fields it now only requires that you find all keywords across any of the fields.  To do this it loops over all keywords calling filterAny once for each keyword passing an array of filters containing all source fields.  Tested with single field or two fields using single or two keywords and seems to be working returning appropriate results.