### PR TITLE
If selection is not required user provided value may be used.

### DIFF
--- a/src/AutoCompleteField.php
+++ b/src/AutoCompleteField.php
@@ -196,13 +196,23 @@ class AutoCompleteField extends TextField
      */
     public function Value()
     {
+        // try to fetch value from selected record
         $record = DataList::create($this->sourceClass)
             ->filter(array(
                 $this->storedField => $this->dataValue()
             ))
             ->first();
 
-        return $record ? $record->{$this->displayField} : '';
+        if ($record) {
+            return $record->{$this->displayField};
+        }
+
+        // if selection is not required, display the user provided value
+        if (!$this->requireSelection && !empty($this->value)) {
+            return $this->value;
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
If a selection is not required we should allow user provided value to be displayed otherwise the UI can be confusing when the user input a search string that doesn't exactly match any of the records.