### PR TITLE
Allow user provided values (fix for 3.5.x)

### DIFF
--- a/code/AutoCompleteField.php
+++ b/code/AutoCompleteField.php
@@ -173,13 +173,23 @@ class AutoCompleteField extends TextField
      */
     public function Value()
     {
+        // try to fetch value from selected record
         $record = DataList::create($this->sourceClass)
             ->filter(array(
                 $this->storedField => $this->dataValue()
             ))
             ->first();
 
-        return $record ? $record->{$this->displayField} : '';
+        if ($record) {
+            return $record->{$this->displayField};
+        }
+
+        // if selection is not required, display the user provided value
+        if (!$this->requireSelection && !empty($this->value)) {
+            return $this->value;
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
**NOTE: This only affects v3.5.2.** This **should** be going against a `3.5` branch, not `3.4` , but should work regardless of which branch it's merged into, so working with what I've got. I tested this in a branch derived from tag `3.5.2` and it merges fine 😎 

This is a port of @mfendeksilverstripe's PR #39 but for the stable `3.x` versions (of this module and versions of SilverStripe).